### PR TITLE
Remove implicit deps from web-shared-assets lib

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -78,7 +78,7 @@
     "web-browse-ui-category-cover": { "tags": ["type:ui", "scope:web"] },
     "web-shared-ui-spinner": { "tags": ["type:ui", "scope:web"] },
     "web-shared-ui-playlist-list": { "tags": ["type:ui", "scope:web"] },
-    "web-shared-assets": { "tags": ["type:assets"], "implicitDependencies": ["angular-spotify"] },
+    "web-shared-assets": { "tags": ["type:assets"] },
     "web-album-feature-detail": { "tags": ["type:feature", "scope:web"] },
     "web-album-feature-list": { "tags": ["type:feature", "scope:web"] },
     "web-album-feature-shell": { "tags": ["type:feature", "scope:web"] },


### PR DESCRIPTION
#### Referenced Issues:
- Resolves #47 

#### Changelog:
- Remove implicit deps between main app and web-shared-assets lib