### PR TITLE
feat(settings): create new lib and persist volume at settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ I followed the structure recommended by my friend [@nartc][nartc]. Below is the 
             │   ├── feature (angular:lib) - for configure any forRoot modules
             │   └── ui
             │       └── layout (angular:lib)
+            ├── settings (dir)
+            │   ├── feature (angular:lib) - for configure and persist all settings
+            │   └── data-access (workspace:lib) - store and services for settings module
             ├── playlist (dir)
             │   ├── data-access (angular:lib, service, state management)
             │   ├── features

--- a/angular.json
+++ b/angular.json
@@ -1562,6 +1562,27 @@
           }
         }
       }
+    },
+    "web-settings-data-access": {
+      "root": "libs/web/settings/data-access",
+      "sourceRoot": "libs/web/settings/data-access/src",
+      "projectType": "library",
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:eslint",
+          "options": {
+            "lintFilePatterns": ["libs/web/settings/data-access/**/*.ts"]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/web/settings/data-access"],
+          "options": {
+            "jestConfig": "libs/web/settings/data-access/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
     }
   }
 }

--- a/angular.json
+++ b/angular.json
@@ -1537,6 +1537,31 @@
           }
         }
       }
+    },
+    "web-settings-feature": {
+      "projectType": "library",
+      "root": "libs/web/settings/feature",
+      "sourceRoot": "libs/web/settings/feature/src",
+      "prefix": "as",
+      "architect": {
+        "lint": {
+          "builder": "@nrwl/linter:eslint",
+          "options": {
+            "lintFilePatterns": [
+              "libs/web/settings/feature/src/**/*.ts",
+              "libs/web/settings/feature/src/**/*.html"
+            ]
+          }
+        },
+        "test": {
+          "builder": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/web/settings/feature"],
+          "options": {
+            "jestConfig": "libs/web/settings/feature/jest.config.js",
+            "passWithNoTests": true
+          }
+        }
+      }
     }
   }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -52,6 +52,7 @@ module.exports = {
     '<rootDir>/libs/web/album/data-access',
     '<rootDir>/libs/web/visualizer/ui',
     '<rootDir>/libs/web/album/ui/album-track',
-    '<rootDir>/libs/web/settings/feature'
+    '<rootDir>/libs/web/settings/feature',
+    '<rootDir>/libs/web/settings/data-access'
   ]
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -51,6 +51,7 @@ module.exports = {
     '<rootDir>/libs/web/album/feature/shell',
     '<rootDir>/libs/web/album/data-access',
     '<rootDir>/libs/web/visualizer/ui',
-    '<rootDir>/libs/web/album/ui/album-track'
+    '<rootDir>/libs/web/album/ui/album-track',
+    '<rootDir>/libs/web/settings/feature'
   ]
 };

--- a/libs/web/settings/data-access/.babelrc
+++ b/libs/web/settings/data-access/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/libs/web/settings/data-access/.eslintrc.json
+++ b/libs/web/settings/data-access/.eslintrc.json
@@ -1,0 +1,21 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "parserOptions": {
+        "project": ["libs/web/settings/data-access/tsconfig.*?.json"]
+      },
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/web/settings/data-access/README.md
+++ b/libs/web/settings/data-access/README.md
@@ -1,0 +1,7 @@
+# web-settings-data-access
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test web-settings-data-access` to execute the unit tests via [Jest](https://jestjs.io).

--- a/libs/web/settings/data-access/jest.config.js
+++ b/libs/web/settings/data-access/jest.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  displayName: 'web-settings-data-access',
+  preset: '../../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsConfig: '<rootDir>/tsconfig.spec.json'
+    }
+  },
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest'
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../../coverage/libs/web/settings/data-access'
+};

--- a/libs/web/settings/data-access/src/index.ts
+++ b/libs/web/settings/data-access/src/index.ts
@@ -1,0 +1,2 @@
+export * from './lib/store';
+export * from './lib/services';

--- a/libs/web/settings/data-access/src/lib/services/index.ts
+++ b/libs/web/settings/data-access/src/lib/services/index.ts
@@ -1,0 +1,1 @@
+export * from './local-storage.service';

--- a/libs/web/settings/data-access/src/lib/services/local-storage.service.ts
+++ b/libs/web/settings/data-access/src/lib/services/local-storage.service.ts
@@ -1,0 +1,84 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { Injectable } from '@angular/core';
+
+const APP_PREFIX = 'AS-';
+
+@Injectable({ providedIn: 'root' })
+export class LocalStorageService {
+  /**
+   * Returns all initial variables
+   * from local storage
+   *
+   * @static
+   * @return {any}
+   */
+  public static loadInitialState(): any {
+    return Object.keys(localStorage).reduce((state: any, storageKey) => {
+      if (storageKey.startsWith(APP_PREFIX)) {
+        const stateKeys = storageKey
+          .replace(APP_PREFIX, '')
+          .toLowerCase()
+          .split('.')
+          .map((key) =>
+            key
+              .split('-')
+              .map((token, index) =>
+                index === 0 ? token : token.charAt(0).toUpperCase() + token.slice(1)
+              )
+              .join('')
+          );
+
+        let currentStateRef = state;
+        stateKeys.forEach((key, index) => {
+          if (index === stateKeys.length - 1) {
+            currentStateRef[key] = JSON.parse(localStorage.getItem(storageKey) as string);
+            return;
+          }
+          currentStateRef[key] = currentStateRef[key] || {};
+          currentStateRef = currentStateRef[key];
+        });
+      }
+
+      return state;
+    }, {});
+  }
+
+  /**
+   * Sets item in local storage
+   *
+   * @param {string} key
+   * @param {*} value
+   */
+  public setItem(key: string, value: any) {
+    try {
+      localStorage.setItem(`${APP_PREFIX}${key}`, JSON.stringify(value));
+    } catch (e) {
+      localStorage.setItem(`${APP_PREFIX}${key}`, value);
+    }
+  }
+
+  /**
+   * Gets item from local storage by key
+   *
+   * @param {string} key
+   * @return {*}  {*}
+   */
+  public getItem(key: string): any {
+    const value = localStorage.getItem(`${APP_PREFIX}${key}`);
+    try {
+      return JSON.parse(value as any);
+    } catch (e) {
+      return value;
+    }
+  }
+
+  /**
+   * Removes item from local storage by key
+   *
+   * @param {string} key
+   */
+  public removeItem(key: string) {
+    localStorage.removeItem(`${APP_PREFIX}${key}`);
+  }
+}

--- a/libs/web/settings/data-access/src/lib/store/index.ts
+++ b/libs/web/settings/data-access/src/lib/store/index.ts
@@ -1,0 +1,4 @@
+export * from './settings.reducer';
+export * from './settings.facade';
+export * from './settings.effects';
+export * from './meta-reducers/init-settings.reducer';

--- a/libs/web/settings/data-access/src/lib/store/meta-reducers/init-settings.reducer.ts
+++ b/libs/web/settings/data-access/src/lib/store/meta-reducers/init-settings.reducer.ts
@@ -1,0 +1,15 @@
+import { ActionReducer, INIT, UPDATE } from '@ngrx/store';
+import { LocalStorageService } from '../../services';
+import { SettingsState } from '../settings.reducer';
+
+export function initSettingsFromLocalStorage(
+  reducer: ActionReducer<SettingsState>
+): ActionReducer<SettingsState> {
+  return (state, action) => {
+    const newState = reducer(state, action);
+    if ([INIT.toString(), UPDATE.toString()].includes(action.type)) {
+      return { ...newState, ...(LocalStorageService.loadInitialState()?.settings ?? {}) };
+    }
+    return newState;
+  };
+}

--- a/libs/web/settings/data-access/src/lib/store/settings.actions.ts
+++ b/libs/web/settings/data-access/src/lib/store/settings.actions.ts
@@ -1,0 +1,3 @@
+import { createAction, props } from '@ngrx/store';
+
+export const persistVolume = createAction('[Settings] Persist Volume', props<{ volume: number }>());

--- a/libs/web/settings/data-access/src/lib/store/settings.effects.ts
+++ b/libs/web/settings/data-access/src/lib/store/settings.effects.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { select, Store } from '@ngrx/store';
+import { createEffect, Actions, ofType } from '@ngrx/effects';
+import { tap, withLatestFrom } from 'rxjs/operators';
+
+import { LocalStorageService } from '../services';
+import * as SettingsActions from './settings.actions';
+import { getSettings } from './settings.selectors';
+import { SettingsState } from './settings.reducer';
+
+export const SETTINGS_KEY = 'SETTINGS';
+
+@Injectable()
+export class SettingsEffects {
+  public persistSettings = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(SettingsActions.persistVolume),
+        withLatestFrom(this.store.pipe(select(getSettings))),
+        tap(([, settings]) => this.localStorageService.setItem(SETTINGS_KEY, settings))
+      ),
+    { dispatch: false }
+  );
+
+  constructor(
+    private actions$: Actions,
+    private store: Store<SettingsState>,
+    private localStorageService: LocalStorageService
+  ) {}
+}

--- a/libs/web/settings/data-access/src/lib/store/settings.facade.ts
+++ b/libs/web/settings/data-access/src/lib/store/settings.facade.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { Store } from '@ngrx/store';
+
+import { SettingsState } from './settings.reducer';
+import * as SettingsActions from './settings.actions';
+import * as SettingsSelectors from './settings.selectors';
+
+@Injectable()
+export class SettingsFacade {
+  public settings$ = this.store.select(SettingsSelectors.getSettings);
+  public volume$ = this.store.select(SettingsSelectors.getSettingsVolume);
+
+  constructor(private store: Store<SettingsState>) {}
+
+  public persistVolume(volume: number) {
+    this.store.dispatch(SettingsActions.persistVolume({ volume }));
+  }
+}

--- a/libs/web/settings/data-access/src/lib/store/settings.reducer.ts
+++ b/libs/web/settings/data-access/src/lib/store/settings.reducer.ts
@@ -1,0 +1,20 @@
+import { createReducer, on } from '@ngrx/store';
+import * as SettingsActions from './settings.actions';
+
+export const SETTINGS_FEATURE_KEY = 'settings';
+
+export interface SettingsState {
+  volume: number;
+}
+
+export const initialState: SettingsState = {
+  volume: 0
+};
+
+export const settingsReducer = createReducer(
+  initialState,
+  on(SettingsActions.persistVolume, (state, { volume }) => ({
+    ...state,
+    volume
+  }))
+);

--- a/libs/web/settings/data-access/src/lib/store/settings.selectors.ts
+++ b/libs/web/settings/data-access/src/lib/store/settings.selectors.ts
@@ -1,0 +1,6 @@
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { SETTINGS_FEATURE_KEY, SettingsState } from './settings.reducer';
+
+export const getSettings = createFeatureSelector<SettingsState>(SETTINGS_FEATURE_KEY);
+
+export const getSettingsVolume = createSelector(getSettings, (state) => state.volume || 0);

--- a/libs/web/settings/data-access/tsconfig.json
+++ b/libs/web/settings/data-access/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/web/settings/data-access/tsconfig.lib.json
+++ b/libs/web/settings/data-access/tsconfig.lib.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "types": []
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["**/*.spec.ts"]
+}

--- a/libs/web/settings/data-access/tsconfig.spec.json
+++ b/libs/web/settings/data-access/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": ["**/*.spec.ts", "**/*.spec.tsx", "**/*.spec.js", "**/*.spec.jsx", "**/*.d.ts"]
+}

--- a/libs/web/settings/feature/.eslintrc.json
+++ b/libs/web/settings/feature/.eslintrc.json
@@ -1,0 +1,25 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nrwl/nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "parserOptions": { "project": ["libs/web/settings/feature/tsconfig.*?.json"] },
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          { "type": "attribute", "prefix": "as", "style": "camelCase" }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          { "type": "element", "prefix": "as", "style": "kebab-case" }
+        ]
+      }
+    },
+    { "files": ["*.html"], "extends": ["plugin:@nrwl/nx/angular-template"], "rules": {} }
+  ]
+}

--- a/libs/web/settings/feature/README.md
+++ b/libs/web/settings/feature/README.md
@@ -1,0 +1,7 @@
+# web-settings-feature
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test web-settings-feature` to execute the unit tests.

--- a/libs/web/settings/feature/jest.config.js
+++ b/libs/web/settings/feature/jest.config.js
@@ -1,0 +1,23 @@
+module.exports = {
+  displayName: 'web-settings-feature',
+  preset: '../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsConfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$',
+      astTransformers: {
+        before: [
+          'jest-preset-angular/build/InlineFilesTransformer',
+          'jest-preset-angular/build/StripStylesTransformer'
+        ]
+      }
+    }
+  },
+  coverageDirectory: '../../../../coverage/libs/web/settings/feature',
+  snapshotSerializers: [
+    'jest-preset-angular/build/AngularNoNgAttributesSnapshotSerializer.js',
+    'jest-preset-angular/build/AngularSnapshotSerializer.js',
+    'jest-preset-angular/build/HTMLCommentSerializer.js'
+  ]
+};

--- a/libs/web/settings/feature/src/index.ts
+++ b/libs/web/settings/feature/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/settings.module';

--- a/libs/web/settings/feature/src/lib/settings.module.ts
+++ b/libs/web/settings/feature/src/lib/settings.module.ts
@@ -1,0 +1,7 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@NgModule({
+  imports: [CommonModule]
+})
+export class SettingsModule {}

--- a/libs/web/settings/feature/src/lib/settings.module.ts
+++ b/libs/web/settings/feature/src/lib/settings.module.ts
@@ -1,7 +1,22 @@
 import { NgModule } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { StoreModule } from '@ngrx/store';
+import { EffectsModule } from '@ngrx/effects';
+
+import {
+  SETTINGS_FEATURE_KEY,
+  settingsReducer,
+  SettingsEffects,
+  SettingsFacade,
+  initSettingsFromLocalStorage
+} from '@angular-spotify/web/settings/data-access';
 
 @NgModule({
-  imports: [CommonModule]
+  imports: [
+    StoreModule.forFeature(SETTINGS_FEATURE_KEY, settingsReducer, {
+      metaReducers: [initSettingsFromLocalStorage]
+    }),
+    EffectsModule.forFeature([SettingsEffects])
+  ],
+  providers: [SettingsFacade]
 })
 export class SettingsModule {}

--- a/libs/web/settings/feature/src/test-setup.ts
+++ b/libs/web/settings/feature/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular';

--- a/libs/web/settings/feature/tsconfig.json
+++ b/libs/web/settings/feature/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "angularCompilerOptions": {
+    "strictInjectionParameters": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/web/settings/feature/tsconfig.lib.json
+++ b/libs/web/settings/feature/tsconfig.lib.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "target": "es2015",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": [],
+    "lib": ["dom", "es2018"]
+  },
+  "angularCompilerOptions": {
+    "skipTemplateCodegen": true,
+    "strictMetadataEmit": true,
+    "enableResourceInlining": true
+  },
+  "exclude": ["src/test-setup.ts", "**/*.spec.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/web/settings/feature/tsconfig.spec.json
+++ b/libs/web/settings/feature/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["**/*.spec.ts", "**/*.d.ts"]
+}

--- a/libs/web/shell/feature/src/lib/web-shell.module.ts
+++ b/libs/web/shell/feature/src/lib/web-shell.module.ts
@@ -4,6 +4,7 @@ import { NgModule, ErrorHandler } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { webShellRoutes } from './web-shell.routes';
 import { WebLayoutModule } from '@angular-spotify/web/shell/ui/layout';
+import { SettingsModule } from '@angular-spotify/web/settings/feature';
 import { StoreModule } from '@ngrx/store';
 import { EffectsModule } from '@ngrx/effects';
 import { IconModule } from '@angular-spotify/web/shared/ui/icon';
@@ -40,7 +41,8 @@ const rootReducers = {
     }),
     StoreModule.forRoot(rootReducers),
     EffectsModule.forRoot([PlaylistsEffect, PlaylistTracksEffect]),
-    ...extModules,
+    SettingsModule,
+    ...extModules
   ],
   exports: [RouterModule],
   providers: [

--- a/nx.json
+++ b/nx.json
@@ -18,7 +18,12 @@
     "default": {
       "runner": "@nrwl/nx-cloud",
       "options": {
-        "cacheableOperations": ["build", "lint", "test", "e2e"],
+        "cacheableOperations": [
+          "build",
+          "lint",
+          "test",
+          "e2e"
+        ],
         "accessToken": "NTI5MmY1OWItM2I3ZC00MmIwLWE0MGMtZTlhYjUyOWI4YzNlfHJlYWQ=",
         "canTrackAnalytics": false,
         "showUsageWarnings": true
@@ -31,64 +36,117 @@
     },
     "angular-spotify-e2e": {
       "tags": [],
-      "implicitDependencies": ["angular-spotify"]
+      "implicitDependencies": [
+        "angular-spotify"
+      ]
     },
     "web-shared-data-access-models": {
       "tags": []
     },
     "web-shared-data-access-spotify-api": {
-      "tags": ["type:data-access", "scope:web"]
+      "tags": [
+        "type:data-access",
+        "scope:web"
+      ]
     },
     "web-auth-data-access": {
-      "tags": ["type:data-access", "scope:web"]
+      "tags": [
+        "type:data-access",
+        "scope:web"
+      ]
     },
     "web-auth-util": {
-      "tags": ["type:data-access", "scope:web"]
+      "tags": [
+        "type:data-access",
+        "scope:web"
+      ]
     },
     "web-shared-app-config": {
       "tags": []
     },
     "web-shared-data-access-store": {
-      "tags": ["type:data-access", "scope:web"]
+      "tags": [
+        "type:data-access",
+        "scope:web"
+      ]
     },
     "web-shared-ui-track-main-info": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-shared-pipes-duration-pipe": {
-      "tags": ["type:pipe", "scope:web"]
+      "tags": [
+        "type:pipe",
+        "scope:web"
+      ]
     },
     "web-shared-ui-icon": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-shared-ui-track-current-info": {
-      "tags": ["type:io", "scope:web"]
+      "tags": [
+        "type:io",
+        "scope:web"
+      ]
     },
     "web-shared-ui-media": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-shared-ui-media-cover": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-shared-ui-media-summary": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-shared-ui-play-button": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-shared-directives-click-stop-propagation": {
-      "tags": ["type:directive", "scope:web"]
+      "tags": [
+        "type:directive",
+        "scope:web"
+      ]
     },
     "web-shared-ui-media-table": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-shared-ui-media-order": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-visualizer-feature": {
-      "tags": ["type:feature", "scope:web"]
+      "tags": [
+        "type:feature",
+        "scope:web"
+      ]
     },
     "web-visualizer-data-access": {
-      "tags": ["type:data-access", "scope:web"]
+      "tags": [
+        "type:data-access",
+        "scope:web"
+      ]
     },
     "web-shell-feature": {
       "tags": []
@@ -109,115 +167,228 @@
       "tags": []
     },
     "web-shell-ui-now-playing-bar": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-shell-ui-player-controls": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-shell-ui-player-playback": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-shell-ui-player-volume": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-playlist-ui-playlist-track": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-playlist-data-access": {
-      "tags": ["type:data-access", "scope:web"]
+      "tags": [
+        "type:data-access",
+        "scope:web"
+      ]
     },
     "web-home-feature": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-home-data-access": {
-      "tags": ["type:data-access", "scope:web"]
+      "tags": [
+        "type:data-access",
+        "scope:web"
+      ]
     },
     "web-home-ui-greeting": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-home-ui-recent-played": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-home-ui-featured-playlists": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-shared-ui-work-in-progress": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-artist-feature": {
-      "tags": ["type:feature", "scope:web"]
+      "tags": [
+        "type:feature",
+        "scope:web"
+      ]
     },
     "web-shared-ui-tracks-loading": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-shell-ui-visualization-toggle": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-playlist-feature-detail": {
-      "tags": ["type:feature", "scope: web"]
+      "tags": [
+        "type:feature",
+        "scope: web"
+      ]
     },
     "web-playlist-feature-list": {
-      "tags": ["type:feature", "scope:web"]
+      "tags": [
+        "type:feature",
+        "scope:web"
+      ]
     },
     "web-auth-ui-unauthorized-modal": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-shell-ui-user-dropdown": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-shell-ui-social-share": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-tracks-feature": {
-      "tags": ["type:feature", "scope:web"]
+      "tags": [
+        "type:feature",
+        "scope:web"
+      ]
     },
     "web-shared-utils": {
-      "tags": ["type:util", "scope:web"]
+      "tags": [
+        "type:util",
+        "scope:web"
+      ]
     },
     "web-shell-ui-album-art-overlay": {
       "tags": []
     },
     "web-browse-feature-categories": {
-      "tags": ["type:feature", "scope:web"]
+      "tags": [
+        "type:feature",
+        "scope:web"
+      ]
     },
     "web-browse-feature-category": {
-      "tags": ["type:feature", "scope:web"]
+      "tags": [
+        "type:feature",
+        "scope:web"
+      ]
     },
     "web-browse-feature-shell": {
-      "tags": ["type:feature", "scope:web"]
+      "tags": [
+        "type:feature",
+        "scope:web"
+      ]
     },
     "web-browse-data-access": {
-      "tags": ["type:data-access", "scope:web"]
+      "tags": [
+        "type:data-access",
+        "scope:web"
+      ]
     },
     "web-browse-ui-category-cover": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-shared-ui-spinner": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-shared-ui-playlist-list": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-shared-assets": {
-      "tags": ["type:assets"]
+      "tags": [
+        "type:assets"
+      ]
     },
     "web-album-feature-detail": {
-      "tags": ["type:feature", "scope:web"]
+      "tags": [
+        "type:feature",
+        "scope:web"
+      ]
     },
     "web-album-feature-list": {
-      "tags": ["type:feature", "scope:web"]
+      "tags": [
+        "type:feature",
+        "scope:web"
+      ]
     },
     "web-album-feature-shell": {
-      "tags": ["type:feature", "scope:web"]
+      "tags": [
+        "type:feature",
+        "scope:web"
+      ]
     },
     "web-album-data-access": {
-      "tags": ["type:data-access", "scope:web"]
+      "tags": [
+        "type:data-access",
+        "scope:web"
+      ]
     },
     "web-visualizer-ui": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
     },
     "web-album-ui-album-track": {
-      "tags": ["type:ui", "scope:web"]
+      "tags": [
+        "type:ui",
+        "scope:web"
+      ]
+    },
+    "web-settings-feature": {
+      "tags": [
+        "type:feature",
+        "scope:web"
+      ]
     }
   }
 }

--- a/nx.json
+++ b/nx.json
@@ -389,6 +389,12 @@
         "type:feature",
         "scope:web"
       ]
+    },
+    "web-settings-data-access": {
+      "tags": [
+        "type:data-access",
+        "scope:web"
+      ]
     }
   }
 }

--- a/nx.json
+++ b/nx.json
@@ -18,12 +18,7 @@
     "default": {
       "runner": "@nrwl/nx-cloud",
       "options": {
-        "cacheableOperations": [
-          "build",
-          "lint",
-          "test",
-          "e2e"
-        ],
+        "cacheableOperations": ["build", "lint", "test", "e2e"],
         "accessToken": "NTI5MmY1OWItM2I3ZC00MmIwLWE0MGMtZTlhYjUyOWI4YzNlfHJlYWQ=",
         "canTrackAnalytics": false,
         "showUsageWarnings": true
@@ -36,117 +31,64 @@
     },
     "angular-spotify-e2e": {
       "tags": [],
-      "implicitDependencies": [
-        "angular-spotify"
-      ]
+      "implicitDependencies": ["angular-spotify"]
     },
     "web-shared-data-access-models": {
       "tags": []
     },
     "web-shared-data-access-spotify-api": {
-      "tags": [
-        "type:data-access",
-        "scope:web"
-      ]
+      "tags": ["type:data-access", "scope:web"]
     },
     "web-auth-data-access": {
-      "tags": [
-        "type:data-access",
-        "scope:web"
-      ]
+      "tags": ["type:data-access", "scope:web"]
     },
     "web-auth-util": {
-      "tags": [
-        "type:data-access",
-        "scope:web"
-      ]
+      "tags": ["type:data-access", "scope:web"]
     },
     "web-shared-app-config": {
       "tags": []
     },
     "web-shared-data-access-store": {
-      "tags": [
-        "type:data-access",
-        "scope:web"
-      ]
+      "tags": ["type:data-access", "scope:web"]
     },
     "web-shared-ui-track-main-info": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-shared-pipes-duration-pipe": {
-      "tags": [
-        "type:pipe",
-        "scope:web"
-      ]
+      "tags": ["type:pipe", "scope:web"]
     },
     "web-shared-ui-icon": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-shared-ui-track-current-info": {
-      "tags": [
-        "type:io",
-        "scope:web"
-      ]
+      "tags": ["type:io", "scope:web"]
     },
     "web-shared-ui-media": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-shared-ui-media-cover": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-shared-ui-media-summary": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-shared-ui-play-button": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-shared-directives-click-stop-propagation": {
-      "tags": [
-        "type:directive",
-        "scope:web"
-      ]
+      "tags": ["type:directive", "scope:web"]
     },
     "web-shared-ui-media-table": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-shared-ui-media-order": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-visualizer-feature": {
-      "tags": [
-        "type:feature",
-        "scope:web"
-      ]
+      "tags": ["type:feature", "scope:web"]
     },
     "web-visualizer-data-access": {
-      "tags": [
-        "type:data-access",
-        "scope:web"
-      ]
+      "tags": ["type:data-access", "scope:web"]
     },
     "web-shell-feature": {
       "tags": []
@@ -167,234 +109,121 @@
       "tags": []
     },
     "web-shell-ui-now-playing-bar": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-shell-ui-player-controls": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-shell-ui-player-playback": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-shell-ui-player-volume": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-playlist-ui-playlist-track": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-playlist-data-access": {
-      "tags": [
-        "type:data-access",
-        "scope:web"
-      ]
+      "tags": ["type:data-access", "scope:web"]
     },
     "web-home-feature": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-home-data-access": {
-      "tags": [
-        "type:data-access",
-        "scope:web"
-      ]
+      "tags": ["type:data-access", "scope:web"]
     },
     "web-home-ui-greeting": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-home-ui-recent-played": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-home-ui-featured-playlists": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-shared-ui-work-in-progress": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-artist-feature": {
-      "tags": [
-        "type:feature",
-        "scope:web"
-      ]
+      "tags": ["type:feature", "scope:web"]
     },
     "web-shared-ui-tracks-loading": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-shell-ui-visualization-toggle": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-playlist-feature-detail": {
-      "tags": [
-        "type:feature",
-        "scope: web"
-      ]
+      "tags": ["type:feature", "scope: web"]
     },
     "web-playlist-feature-list": {
-      "tags": [
-        "type:feature",
-        "scope:web"
-      ]
+      "tags": ["type:feature", "scope:web"]
     },
     "web-auth-ui-unauthorized-modal": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-shell-ui-user-dropdown": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-shell-ui-social-share": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-tracks-feature": {
-      "tags": [
-        "type:feature",
-        "scope:web"
-      ]
+      "tags": ["type:feature", "scope:web"]
     },
     "web-shared-utils": {
-      "tags": [
-        "type:util",
-        "scope:web"
-      ]
+      "tags": ["type:util", "scope:web"]
     },
     "web-shell-ui-album-art-overlay": {
       "tags": []
     },
     "web-browse-feature-categories": {
-      "tags": [
-        "type:feature",
-        "scope:web"
-      ]
+      "tags": ["type:feature", "scope:web"]
     },
     "web-browse-feature-category": {
-      "tags": [
-        "type:feature",
-        "scope:web"
-      ]
+      "tags": ["type:feature", "scope:web"]
     },
     "web-browse-feature-shell": {
-      "tags": [
-        "type:feature",
-        "scope:web"
-      ]
+      "tags": ["type:feature", "scope:web"]
     },
     "web-browse-data-access": {
-      "tags": [
-        "type:data-access",
-        "scope:web"
-      ]
+      "tags": ["type:data-access", "scope:web"]
     },
     "web-browse-ui-category-cover": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-shared-ui-spinner": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-shared-ui-playlist-list": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-shared-assets": {
-      "tags": [
-        "type:assets"
-      ]
+      "tags": ["type:assets"]
     },
     "web-album-feature-detail": {
-      "tags": [
-        "type:feature",
-        "scope:web"
-      ]
+      "tags": ["type:feature", "scope:web"]
     },
     "web-album-feature-list": {
-      "tags": [
-        "type:feature",
-        "scope:web"
-      ]
+      "tags": ["type:feature", "scope:web"]
     },
     "web-album-feature-shell": {
-      "tags": [
-        "type:feature",
-        "scope:web"
-      ]
+      "tags": ["type:feature", "scope:web"]
     },
     "web-album-data-access": {
-      "tags": [
-        "type:data-access",
-        "scope:web"
-      ]
+      "tags": ["type:data-access", "scope:web"]
     },
     "web-visualizer-ui": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-album-ui-album-track": {
-      "tags": [
-        "type:ui",
-        "scope:web"
-      ]
+      "tags": ["type:ui", "scope:web"]
     },
     "web-settings-feature": {
-      "tags": [
-        "type:feature",
-        "scope:web"
-      ]
+      "tags": ["type:feature", "scope:web"]
     },
     "web-settings-data-access": {
-      "tags": [
-        "type:data-access",
-        "scope:web"
-      ]
+      "tags": ["type:data-access", "scope:web"]
     }
   }
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -130,7 +130,8 @@
       "@angular-spotify/web/album/data-access": ["libs/web/album/data-access/src/index.ts"],
       "@angular-spotify/web/visualizer/ui": ["libs/web/visualizer/ui/src/index.ts"],
       "@angular-spotify/web/album/ui/album-track": ["libs/web/album/ui/album-track/src/index.ts"],
-      "@angular-spotify/web/settings/feature": ["libs/web/settings/feature/src/index.ts"]
+      "@angular-spotify/web/settings/feature": ["libs/web/settings/feature/src/index.ts"],
+      "@angular-spotify/web/settings/data-access": ["libs/web/settings/data-access/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -129,7 +129,8 @@
       "@angular-spotify/web/album/feature/shell": ["libs/web/album/feature/shell/src/index.ts"],
       "@angular-spotify/web/album/data-access": ["libs/web/album/data-access/src/index.ts"],
       "@angular-spotify/web/visualizer/ui": ["libs/web/visualizer/ui/src/index.ts"],
-      "@angular-spotify/web/album/ui/album-track": ["libs/web/album/ui/album-track/src/index.ts"]
+      "@angular-spotify/web/album/ui/album-track": ["libs/web/album/ui/album-track/src/index.ts"],
+      "@angular-spotify/web/settings/feature": ["libs/web/settings/feature/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
#### Referenced Issues:
- Resolves #23 

#### Changelog:
- Create 2 new libs: `settings-feature`, `settings-data-access` 
- Persist volume locally on change
- Load volume from storage on init
- Update `README.md` file