### PR TITLE
feat: add duration title to clock svg on album and playlist media table header

### DIFF
--- a/libs/web/album/feature/detail/src/lib/album.component.html
+++ b/libs/web/album/feature/detail/src/lib/album.component.html
@@ -18,7 +18,7 @@
       <div class="album-tracks-grid">
         <div>#</div>
         <div class="text-xs uppercase ellipsis-one-line">Title</div>
-        <svg-icon [key]="'clock'"></svg-icon>
+        <svg-icon [key]="'clock'" title="duration"></svg-icon>
       </div>
     </as-media-table-header>
 

--- a/libs/web/playlist/feature/detail/src/lib/playlist.component.html
+++ b/libs/web/playlist/feature/detail/src/lib/playlist.component.html
@@ -27,7 +27,7 @@
       <div class="text-xs uppercase ellipsis-one-line">Title</div>
       <div class="text-xs uppercase ellipsis-one-line">Album</div>
       <div class="text-xs uppercase ellipsis-one-line">Date added</div>
-      <svg-icon [key]="'clock'"></svg-icon>
+      <svg-icon [key]="'clock'" title="duration"></svg-icon>
     </div>
   </as-media-table-header>
 


### PR DESCRIPTION
### **Changelog**

- Added `'duration'` title to clock svg on album and playlist `media-table-header`

![image](https://user-images.githubusercontent.com/20175578/117692107-4eebdf80-b1da-11eb-9f39-3852993ba206.png)
