### PR TITLE
feat(media-summary): Add album release year, update display info.

### DIFF
--- a/libs/web/album/feature/detail/src/lib/album.component.html
+++ b/libs/web/album/feature/detail/src/lib/album.component.html
@@ -4,7 +4,8 @@
                       [title]="album.name"
                       [imageUrl]="album.images[0]?.url"
                       [artist]="album.artists[0]?.name"
-                      [trackCount]="album.tracks.total">
+                      [trackCount]="album.tracks.total"
+                      [releaseDate]="album.release_date">
     </as-media-summary>
     <div class="pt-0 pb-6">
       <as-play-button [large]="true"

--- a/libs/web/shared/ui/media-summary/src/lib/media-summary.component.html
+++ b/libs/web/shared/ui/media-summary/src/lib/media-summary.component.html
@@ -3,13 +3,12 @@
 <div class="flex flex-col">
   <h3 class="text-sm text-white uppercase">{{ type }}</h3>
   <h2 class="media-title ellipsis-one-line">{{ title }}</h2>
-  <div class="mt-3 mb-2 text-description">
-    {{ description }}
-  </div>
+  <div class="mt-3 mb-2 text-description" [innerHTML]="description"></div>
   <div class="flex">
     <div class="text-sm font-bold text-white" *ngIf="artist">{{ artist }}</div>
-    <div class="media-info" *ngIf="likesCount">{{ likesCount }} likes</div>
-    <div class="media-info" *ngIf="trackCount">{{ trackCount }} songs</div>
-    <div class="media-info" *ngIf="followerCount">{{ followerCount }} followers</div>
+    <div class="media-info" *ngIf="likesCount">{{ likesCount | i18nPlural : likeMapping}}</div>
+    <div class="media-info" *ngIf="releaseDate">{{ releaseDate | date:'yyyy'}}</div>
+    <div class="media-info" *ngIf="trackCount">{{ trackCount | i18nPlural : songMapping }}</div>
+    <div class="media-info" *ngIf="followerCount">{{ followerCount | i18nPlural : followerMapping }}</div>
   </div>
 </div>

--- a/libs/web/shared/ui/media-summary/src/lib/media-summary.component.scss
+++ b/libs/web/shared/ui/media-summary/src/lib/media-summary.component.scss
@@ -15,7 +15,7 @@
 .media-info {
   @apply text-white text-opacity-70;
 
-  &:before {
+  &:not(:first-child):before {
     content: '•';
     margin: 0px 4px;
   }

--- a/libs/web/shared/ui/media-summary/src/lib/media-summary.component.ts
+++ b/libs/web/shared/ui/media-summary/src/lib/media-summary.component.ts
@@ -15,4 +15,9 @@ export class MediaSummaryComponent {
   @Input() likesCount: number | undefined;
   @Input() followerCount: number | undefined;
   @Input() imageUrl: string | undefined;
+  @Input() releaseDate: string | undefined;
+
+  likeMapping: {[k: string]: string} = {'=1': '# like', 'other': '# likes'};
+  songMapping: {[k: string]: string} = {'=1': '# song', 'other': '# songs'};
+  followerMapping: {[k: string]: string} = {'=1': '# follower', 'other': '# followers'};
 }


### PR DESCRIPTION
**Updates:**
- Add album release date
- handle singular/plural usage
- fix description to display HTML

Support HTML elements for description.
![image](https://user-images.githubusercontent.com/13523782/118076007-379a2700-b37f-11eb-9308-350e7595a849.png)
![image](https://user-images.githubusercontent.com/13523782/118075899-fd308a00-b37e-11eb-8344-988755510e7c.png)

Although will probably not work for Spotify genres as it shows this locally. But will look better in terms of user experience to not see HTML elements.
`<a href="unsafe:spotify:genre:edm_dance">dance music</a>`

![image](https://user-images.githubusercontent.com/13523782/118075531-27357c80-b37e-11eb-80ca-2db04c744415.png)