### PR TITLE
Bringing Cursor back to the search input after clearing input

### DIFF
--- a/libs/web/search/feature/src/lib/search.component.ts
+++ b/libs/web/search/feature/src/lib/search.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { debounceTime, distinctUntilChanged, filter, map } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, filter } from 'rxjs/operators';
 import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
 
 import { RouterUtil } from '@angular-spotify/web/shared/utils';

--- a/libs/web/shared/ui/input/src/lib/input.component.ts
+++ b/libs/web/shared/ui/input/src/lib/input.component.ts
@@ -41,6 +41,7 @@ export class InputComponent implements AfterViewInit {
 
   clear() {
     this.control.patchValue('');
+    this.inputRef.nativeElement.focus();
   }
 
   ngAfterViewInit() {


### PR DESCRIPTION
### This PR contains minor changes

* Bringing Cursor back to the search input after clearing input (input.component.ts)
* Removing unused import of 'map' operator from search.component.ts 