### PR TITLE
fix(application:effects): removal of unused RxJs operator

### DIFF
--- a/libs/web/shared/app-init/src/lib/application.effects.ts
+++ b/libs/web/shared/app-init/src/lib/application.effects.ts
@@ -5,7 +5,7 @@ import { Injectable } from '@angular/core';
 import { NavigationEnd, Router } from '@angular/router';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { combineLatest } from 'rxjs';
-import { filter, map, switchMap, tap, withLatestFrom } from 'rxjs/operators';
+import { filter, switchMap, tap, withLatestFrom } from 'rxjs/operators';
 import { AppInit, AuthReady } from './app-init.action';
 import { GoogleAnalyticsService } from './google-analytics.service';
 import { PromptUpdateService } from './promp-update.service';


### PR DESCRIPTION
During compile time, unused "map" operator caused a failure with "noUnusedLocals" set to "true" in "tsconfig.base.json".