### PR TITLE
fix: add missing position: relative that leak the background photo fullsize

### DIFF
--- a/libs/web/container-queries/src/lib/container-queries.component.ts
+++ b/libs/web/container-queries/src/lib/container-queries.component.ts
@@ -26,7 +26,7 @@ import { NzButtonModule } from 'ng-zorro-antd/button';
           nz-button
           class="text-xl text-primary btn-with-icon"
           target="_blank"
-          href="https://trungk18.com/wdc23"
+          href="https://trungvose.com/talks/2023-06-08-web-directions-code/"
           >👉 View my slide</a
           >
         </div>
@@ -52,7 +52,7 @@ import { NzButtonModule } from 'ng-zorro-antd/button';
           </div>
         </div>
       </div>
-    
+
       <ng-template #cards let-albums="albums">
         @for (item of albums; track item) {
           <as-card

--- a/libs/web/future-responsive/src/lib/future-responsive.component.ts
+++ b/libs/web/future-responsive/src/lib/future-responsive.component.ts
@@ -1,28 +1,31 @@
-import { DataSizeObserverDirective } from '@angular-spotify/web/shared/directives/data-size-observer';
-import { CardComponent } from '@angular-spotify/web/shared/ui/media';
-
 import { Component } from '@angular/core';
 import { NzButtonModule } from 'ng-zorro-antd/button';
-import { ResponsiveToContainerComponent } from './responsive-container.component';
 import { ResponsiveToContentComponent } from './content/responsive-content.component';
+import { ResponsiveToContainerComponent } from './responsive-container.component';
 
 @Component({
   selector: 'as-future-responsive',
   standalone: true,
   imports: [
-    CardComponent,
-    DataSizeObserverDirective,
     NzButtonModule,
     ResponsiveToContentComponent,
     ResponsiveToContainerComponent
-],
+  ],
   template: `
     <div class="content-spacing pb-[250px]">
       <h1 class="text-3xl text-white">Hello London 🏴󠁧󠁢󠁥󠁮󠁧󠁿</h1>
+      <div class="flex pb-6">
+        <a
+          nz-button
+          class="text-xl text-primary btn-with-icon"
+          target="_blank"
+          href="https://trungvose.com/talks/2024-01-29-ndc-london/"
+          >👉 View my slide</a
+        >
+      </div>
       <as-responsive-to-content class="block mb-20"></as-responsive-to-content>
       <as-responsive-to-container></as-responsive-to-container>
     </div>
   `
 })
-export class FutureResponsiveComponent {
-}
+export class FutureResponsiveComponent {}

--- a/libs/web/shared/ui/media/src/lib/card.component.scss
+++ b/libs/web/shared/ui/media/src/lib/card.component.scss
@@ -1,4 +1,5 @@
 :host {
+  position: relative;
   border-radius: 4px;
   transition: background-color 0.3s ease;
   display: flex;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Trung Vo",
     "email": "trungk18@gmail.com",
-    "url": "https://github.com/trungk18"
+    "url": "https://github.com/trungvose"
   },
   "scripts": {
     "ng": "nx",


### PR DESCRIPTION
## Before

Happening on prod, looks like a missing position: relative so the background photo is leaking and covering the whole container. I have not checked those routes for a while, so not sure when it started 🤣

![CleanShot 2025-09-11 at 23 15 29@2x](https://github.com/user-attachments/assets/007cf05c-e324-4b3f-94e5-94c0f3589bfd)

## After 

Back to normal

![CleanShot 2025-09-11 at 23 24 09@2x](https://github.com/user-attachments/assets/a8bd6741-64f6-4204-bd84-481b09863737)
