### PR TITLE
fix(visualizer): add continuous base motion for smoother animations

### DIFF
--- a/libs/web/visualizer/data-access/src/lib/circular-ring-renderer.ts
+++ b/libs/web/visualizer/data-access/src/lib/circular-ring-renderer.ts
@@ -9,6 +9,10 @@ const AMPLITUDE_RATIO = 0.15;
 const LINE_WIDTH = 2;
 const GLOW_BLUR = 20;
 const SMOOTHING = 0.15;
+const ROTATION_SPEED = 0.006;
+const BREATH_AMP = 0.03; // gentle pulsing amplitude
+const BREATH_SPEED = 0.03; // breathing speed
+const MIN_ENERGY_FLOOR = 0.2; // minimum energy multiplier so rings always wobble
 
 export class CircularRingRenderer implements VisualizerRenderer {
   private smoothedPitches: number[] = new Array(12).fill(0);
@@ -16,6 +20,7 @@ export class CircularRingRenderer implements VisualizerRenderer {
   private currentBeatPhase = 0;
   private rotation = 0;
   private colorIndex = 0;
+  private time = 0;
 
   setup(width: number, height: number): void {
     this.smoothedPitches = new Array(12).fill(0);
@@ -23,6 +28,7 @@ export class CircularRingRenderer implements VisualizerRenderer {
     this.currentBeatPhase = 0;
     this.rotation = 0;
     this.colorIndex = 0;
+    this.time = 0;
   }
 
   updateAudio(audioData: AudioData): void {
@@ -44,8 +50,9 @@ export class CircularRingRenderer implements VisualizerRenderer {
     const baseRadius = minDim * BASE_RADIUS_RATIO;
     const amplitude = minDim * AMPLITUDE_RATIO;
 
-    // Slow rotation
-    this.rotation += 0.003;
+    // Continuous rotation
+    this.rotation += ROTATION_SPEED;
+    this.time += BREATH_SPEED;
 
     // Beat pulse
     const beatPulse = 1.0 + Math.max(0, 1.0 - this.currentBeatPhase * 3) * 0.1 * this.currentEnergy;
@@ -54,7 +61,9 @@ export class CircularRingRenderer implements VisualizerRenderer {
     for (let ring = 0; ring < 3; ring++) {
       const ringOffset = ring * 0.15;
       const ringAlpha = (0.7 - ring * 0.2) * (0.3 + this.currentEnergy * 0.7);
-      const ringRadius = baseRadius * (1 + ring * 0.3) * beatPulse;
+      // Base breathing: gentle pulsing per ring at different rates
+      const breath = 1 + Math.sin(this.time + ring * 1.2) * BREATH_AMP;
+      const ringRadius = baseRadius * (1 + ring * 0.3) * beatPulse * breath;
       const color = COLORS[Math.floor(this.colorIndex + ring * 4) % COLORS.length];
 
       ctx.save();
@@ -74,7 +83,8 @@ export class CircularRingRenderer implements VisualizerRenderer {
         const frac = pitchPos - Math.floor(pitchPos);
         const pitchValue = this.smoothedPitches[pitchIdx] * (1 - frac) + this.smoothedPitches[nextIdx] * frac;
 
-        const distortion = pitchValue * amplitude * this.currentEnergy * 2;
+        // Minimum energy floor so rings always wobble slightly
+        const distortion = pitchValue * amplitude * (MIN_ENERGY_FLOOR + this.currentEnergy * 1.8);
         const r = ringRadius + distortion;
 
         const x = cx + Math.cos(angle) * r;

--- a/libs/web/visualizer/data-access/src/lib/lissajous-renderer.ts
+++ b/libs/web/visualizer/data-access/src/lib/lissajous-renderer.ts
@@ -8,6 +8,9 @@ const TRAIL_LENGTH = 400;
 const BASE_SCALE_RATIO = 0.3;
 const GLOW_BLUR = 12;
 const SMOOTHING = 0.1;
+const BASE_PHASE_SPEED = 0.02; // always clearly moving
+const ENERGY_PHASE_BOOST = 0.008;
+const FREQ_MORPH_RATE = 0.04; // more responsive shape changes
 
 export class LissajousRenderer implements VisualizerRenderer {
   private phase = 0;
@@ -40,8 +43,8 @@ export class LissajousRenderer implements VisualizerRenderer {
     // Morph frequency ratios based on dominant pitches
     const p0 = this.smoothedPitches[0] + this.smoothedPitches[4] + this.smoothedPitches[7];
     const p1 = this.smoothedPitches[2] + this.smoothedPitches[5] + this.smoothedPitches[9];
-    this.freqA += ((2 + p0 * 3) - this.freqA) * 0.02;
-    this.freqB += ((3 + p1 * 2) - this.freqB) * 0.02;
+    this.freqA += ((2 + p0 * 3) - this.freqA) * FREQ_MORPH_RATE;
+    this.freqB += ((3 + p1 * 2) - this.freqB) * FREQ_MORPH_RATE;
   }
 
   draw(ctx: CanvasRenderingContext2D, width: number, height: number): void {
@@ -51,8 +54,8 @@ export class LissajousRenderer implements VisualizerRenderer {
     const cy = height / 2;
     const scale = Math.min(width, height) * BASE_SCALE_RATIO;
 
-    // Advance phase
-    this.phase += 0.008 + this.smoothedEnergy * 0.01;
+    // Advance phase — always clearly moving
+    this.phase += BASE_PHASE_SPEED + this.smoothedEnergy * ENERGY_PHASE_BOOST;
     this.hueOffset += 0.5;
 
     // Beat pulse scale

--- a/libs/web/visualizer/data-access/src/lib/radial-spikes-renderer.ts
+++ b/libs/web/visualizer/data-access/src/lib/radial-spikes-renderer.ts
@@ -9,18 +9,23 @@ const MAX_SPIKE_RATIO = 0.3;
 const GLOW_BLUR = 15;
 const SMOOTHING = 0.2;
 const LINE_WIDTH = 2;
+const ROTATION_SPEED = 0.005;
+const MIN_SPIKE_RATIO = 0.04; // minimum spike length ratio
+const WAVE_SPEED = 0.05; // speed of the rotating wave pattern
 
 export class RadialSpikesRenderer implements VisualizerRenderer {
   private smoothedValues: number[] = new Array(NUM_SPIKES).fill(0);
   private currentEnergy = 0;
   private currentBeatPhase = 0;
   private rotation = 0;
+  private time = 0;
 
   setup(width: number, height: number): void {
     this.smoothedValues = new Array(NUM_SPIKES).fill(0);
     this.currentEnergy = 0;
     this.currentBeatPhase = 0;
     this.rotation = 0;
+    this.time = 0;
   }
 
   updateAudio(audioData: AudioData): void {
@@ -48,16 +53,20 @@ export class RadialSpikesRenderer implements VisualizerRenderer {
     const innerRadius = minDim * INNER_RADIUS_RATIO;
     const maxSpike = minDim * MAX_SPIKE_RATIO;
 
-    // Slow rotation
-    this.rotation += 0.002;
+    // Continuous rotation
+    this.rotation += ROTATION_SPEED;
+    this.time += WAVE_SPEED;
 
     // Beat pulse
     const beatPulse = 1.0 + Math.max(0, 1.0 - this.currentBeatPhase * 3) * 0.15 * this.currentEnergy;
+    const minSpike = minDim * MIN_SPIKE_RATIO;
 
     for (let i = 0; i < NUM_SPIKES; i++) {
       const angle = (i / NUM_SPIKES) * TWO_PI + this.rotation;
       const value = this.smoothedValues[i] * this.currentEnergy * 2;
-      const spikeLength = innerRadius + value * maxSpike * beatPulse;
+      // Per-spike wave animation: rotating wave pattern for continuous motion
+      const waveMotion = minSpike * (0.5 + 0.5 * Math.sin(this.time + i * TWO_PI / NUM_SPIKES));
+      const spikeLength = innerRadius + waveMotion + value * maxSpike * beatPulse;
       const color = COLORS[i % COLORS.length];
 
       const x1 = cx + Math.cos(angle) * innerRadius;
@@ -71,7 +80,7 @@ export class RadialSpikesRenderer implements VisualizerRenderer {
       ctx.lineTo(x2, y2);
       ctx.strokeStyle = color;
       ctx.lineWidth = LINE_WIDTH + value * 2;
-      ctx.globalAlpha = 0.4 + this.currentEnergy * 0.6;
+      ctx.globalAlpha = 0.3 + this.currentEnergy * 0.7;
       ctx.shadowColor = color;
       ctx.shadowBlur = GLOW_BLUR * this.currentEnergy;
       ctx.lineCap = 'round';

--- a/libs/web/visualizer/data-access/src/lib/sound-lines-renderer.ts
+++ b/libs/web/visualizer/data-access/src/lib/sound-lines-renderer.ts
@@ -8,18 +8,23 @@ const POINTS_PER_LINE = 100;
 const MAX_AMPLITUDE = 40;
 const SMOOTHING = 0.12;
 const LINE_SPACING_RATIO = 0.6;
+const BASE_PHASE_SPEED = 0.05; // always visibly moving
+const ENERGY_PHASE_BOOST = 0.02; // energy adds speed, doesn't gate it
+const MIN_AMP_FACTOR = 0.15; // minimum amplitude floor
 
 export class SoundLinesRenderer implements VisualizerRenderer {
   private smoothedPitches: number[] = new Array(12).fill(0);
   private currentEnergy = 0;
   private currentBeatPhase = 0;
   private phase = 0;
+  private driftPhase = 0; // secondary slow drift for organic feel
 
   setup(width: number, height: number): void {
     this.smoothedPitches = new Array(12).fill(0);
     this.currentEnergy = 0;
     this.currentBeatPhase = 0;
     this.phase = 0;
+    this.driftPhase = 0;
   }
 
   updateAudio(audioData: AudioData): void {
@@ -35,7 +40,8 @@ export class SoundLinesRenderer implements VisualizerRenderer {
   draw(ctx: CanvasRenderingContext2D, width: number, height: number): void {
     ctx.globalCompositeOperation = 'lighter';
 
-    this.phase += 0.02 + this.currentEnergy * 0.03;
+    this.phase += BASE_PHASE_SPEED + this.currentEnergy * ENERGY_PHASE_BOOST;
+    this.driftPhase += 0.013; // slow secondary drift for organic feel
 
     const totalHeight = height * LINE_SPACING_RATIO;
     const startY = (height - totalHeight) / 2;
@@ -54,7 +60,8 @@ export class SoundLinesRenderer implements VisualizerRenderer {
       const pitchInfluence = this.smoothedPitches[pitchIdx1] * (1 - pitchMix) +
                              this.smoothedPitches[pitchIdx2] * pitchMix;
 
-      const amp = MAX_AMPLITUDE * (pitchInfluence * 2 + this.currentEnergy) * (1 + beatBoost * 0.5);
+      // Minimum amplitude floor so waves always undulate visibly
+      const amp = MAX_AMPLITUDE * (MIN_AMP_FACTOR + pitchInfluence * 1.5 + this.currentEnergy * 0.5) * (1 + beatBoost * 0.5);
       const color = COLORS[line % COLORS.length];
 
       ctx.save();
@@ -76,7 +83,8 @@ export class SoundLinesRenderer implements VisualizerRenderer {
         const freq1 = 2 + pitchIdx1 * 0.5;
         const freq2 = 3 + pitchIdx2 * 0.3;
         const wave = Math.sin(xRatio * TWO_PI * freq1 + this.phase + line * 0.4) * 0.6 +
-                     Math.sin(xRatio * TWO_PI * freq2 + this.phase * 1.3 + line * 0.2) * 0.4;
+                     Math.sin(xRatio * TWO_PI * freq2 + this.phase * 1.3 + line * 0.2) * 0.3 +
+                     Math.sin(xRatio * TWO_PI * 1.5 + this.driftPhase + line * 0.7) * 0.1;
 
         const y = baseY + wave * amp * envelope;
 

--- a/libs/web/visualizer/data-access/src/lib/waveform-bars-renderer.ts
+++ b/libs/web/visualizer/data-access/src/lib/waveform-bars-renderer.ts
@@ -3,13 +3,15 @@ import { AudioData, VisualizerRenderer } from './visualizer-renderer.interface';
 
 const NUM_BARS = 12;
 const RISE_SPEED = 0.3; // how fast bars rise toward target
-const FALL_SPEED = 0.3; // how fast bars fall back down (slower = smoother)
+const FALL_SPEED = 0.15; // slower fall for smoother decay (asymmetric rise/fall)
 const GLOW_BLUR = 15;
 const BAR_GAP_RATIO = 0.3; // gap between bars as ratio of bar width
 const MAX_HEIGHT_RATIO = 0.85; // max bar height as ratio of canvas height
 const MIN_HEIGHT_RATIO = 0.02; // min bar height to always show something
 const REFLECTION_ALPHA = 0.15;
 const REFLECTION_HEIGHT_RATIO = 0.3;
+const IDLE_AMP = 0.03; // amplitude of idle breathing oscillation
+const IDLE_SPEED = 0.04; // speed of idle breathing
 
 export class WaveformBarsRenderer implements VisualizerRenderer {
   private currentHeights: number[] = new Array(NUM_BARS).fill(0);
@@ -17,12 +19,14 @@ export class WaveformBarsRenderer implements VisualizerRenderer {
   private currentEnergy = 0;
   private currentBeatPhase = 0;
   private barColors: string[] = [];
+  private time = 0;
 
   setup(width: number, height: number): void {
     this.currentHeights = new Array(NUM_BARS).fill(0);
     this.targetHeights = new Array(NUM_BARS).fill(0);
     this.currentEnergy = 0;
     this.currentBeatPhase = 0;
+    this.time = 0;
     // Assign colors from the palette, cycling if needed
     this.barColors = Array.from({ length: NUM_BARS }, (_, i) => COLORS[i % COLORS.length]);
   }
@@ -39,6 +43,7 @@ export class WaveformBarsRenderer implements VisualizerRenderer {
 
   draw(ctx: CanvasRenderingContext2D, width: number, height: number): void {
     ctx.globalCompositeOperation = 'lighter';
+    this.time += IDLE_SPEED;
 
     const totalBarSpace = width * 0.8; // use 80% of width
     const startX = (width - totalBarSpace) / 2;
@@ -50,13 +55,16 @@ export class WaveformBarsRenderer implements VisualizerRenderer {
     const beatPulse = 1.0 + Math.max(0, 1.0 - this.currentBeatPhase * 4) * 0.08;
 
     for (let i = 0; i < NUM_BARS; i++) {
-      // Smooth lerp: rise fast, fall gently
+      // Smooth lerp: rise fast, fall gently (asymmetric)
       const diff = this.targetHeights[i] - this.currentHeights[i];
       const speed = diff > 0 ? RISE_SPEED : FALL_SPEED;
       this.currentHeights[i] += diff * speed;
 
+      // Idle breathing: gentle sine-wave oscillation per bar
+      const idleBreath = MIN_HEIGHT_RATIO + IDLE_AMP * (0.5 + 0.5 * Math.sin(this.time + i * 0.6));
+
       const barHeight = Math.max(
-        height * MIN_HEIGHT_RATIO,
+        height * idleBreath,
         this.currentHeights[i] * height * MAX_HEIGHT_RATIO * beatPulse
       );
 


### PR DESCRIPTION
## Summary
- Added continuous autonomous base motion to all 5 non-Particles visualizations (Waveform Bars, Sound Lines, Circular Ring, Radial Spikes, Lissajous)
- The Particles visualization felt smooth because it moves every frame regardless of audio. The other renderers were almost entirely audio-gated, causing a "jiggling" effect when audio data updates every 100ms at 60fps rendering
- Applied the same principle: **continuous motion every frame**, with audio modulating intensity rather than gating movement

## Changes per renderer
| Renderer | Key Changes |
|----------|------------|
| **Waveform Bars** | Idle breathing oscillation per bar, asymmetric rise/fall (slower decay) |
| **Sound Lines** | 2.5x faster base phase, minimum amplitude floor, secondary drift phase |
| **Circular Ring** | 2x faster rotation, per-ring breathing animation, minimum energy floor |
| **Radial Spikes** | 2.5x faster rotation, per-spike wave animation pattern |
| **Lissajous** | 2.5x faster base phase, 2x faster frequency morphing |

## Test plan
- [ ] Open visualizer and play a track
- [ ] Switch between all 6 visualization types
- [ ] Verify all visualizations have visible continuous motion even during quiet passages
- [ ] Verify Particles still feels the same (unchanged)
- [ ] Test during both loud and quiet sections — nothing should appear static or jiggling

🤖 Generated with [Claude Code](https://claude.com/claude-code)