### PR TITLE
fix(pinyin): sort translation queue by active line, not window end

### DIFF
--- a/libs/web/lyrics/data-access/src/lib/pinyin.models.ts
+++ b/libs/web/lyrics/data-access/src/lib/pinyin.models.ts
@@ -15,6 +15,7 @@ export interface PinyinState {
   downloadState: PinyinDownloadState;
   isChinese: boolean;
   pinyinByIndex: Record<number, PinyinLineState>;
+  activeLine: number;
   windowEnd: number;
   visibleRange: { start: number; end: number } | null;
 }

--- a/libs/web/lyrics/data-access/src/lib/pinyin.store.ts
+++ b/libs/web/lyrics/data-access/src/lib/pinyin.store.ts
@@ -21,6 +21,7 @@ const initialState: PinyinState = {
   downloadState: 'idle',
   isChinese: false,
   pinyinByIndex: {},
+  activeLine: -1,
   windowEnd: -1,
   visibleRange: null
 };
@@ -82,7 +83,7 @@ export class PinyinStore extends ComponentStore<PinyinState> {
 
   setActiveLine(line: number): void {
     const windowEnd = line + LOOKAHEAD;
-    this.patchState({ windowEnd });
+    this.patchState({ activeLine: line, windowEnd });
     this.enqueue();
   }
 
@@ -134,8 +135,8 @@ export class PinyinStore extends ComponentStore<PinyinState> {
   }
 
   private get focus(): number {
-    const { windowEnd, visibleRange } = this.get();
-    return windowEnd >= 0 ? windowEnd : (visibleRange ? visibleRange.start : 0);
+    const { activeLine, visibleRange } = this.get();
+    return activeLine >= 0 ? activeLine : (visibleRange ? visibleRange.start : 0);
   }
 
   private enqueue(): void {
@@ -237,6 +238,7 @@ export class PinyinStore extends ComponentStore<PinyinState> {
       downloadState: 'idle',
       isChinese: false,
       pinyinByIndex: {},
+      activeLine: -1,
       windowEnd: -1,
       visibleRange: null
     });


### PR DESCRIPTION
## Problem

When playing a Chinese song, lines ahead of the current position were being translated to pinyin *before* lines at or behind the current position. This caused a visible out-of-order effect: future lines appeared in pinyin first, then the current and past lines caught up later.

## Root cause

The `focus` value used to sort `nextBatch()` was `windowEnd` (`activeLine + LOOKAHEAD`). With LOOKAHEAD = 10, if the user was on line 10, focus was 20. The queue was sorted by distance from 20, so lines 19, 18, 17... were processed first — future lines ahead of where the user was reading.

## Fix

Store `activeLine` separately in state and use it as the sort anchor in `focus`. The look-ahead window for queue inclusion (`index <= windowEnd`) is unchanged — we still prefetch up to 10 lines ahead. But the **priority order** now puts lines closest to the current playback position first.

## Data flow

```mermaid
sequenceDiagram
    participant P as Playback
    participant S as PinyinStore
    participant Q as Queue

    P->>S: setActiveLine(line)
    S->>S: activeLine = line<br/>windowEnd = line + LOOKAHEAD
    S->>Q: enqueue() — all pending where index ≤ windowEnd
    Q->>Q: sort by distance from activeLine (was: windowEnd)
    Q->>S: nextBatch() — lines closest to current position first
```

## Test plan

- [x] All existing `pinyin.store.spec.ts` tests pass (26/26)
- [ ] Play a Chinese song — current and nearby lines translate before far-ahead lines
- [ ] Seek to a mid-song position — lines around the seek point translate first

🤖 Generated with [Claude Code](https://claude.com/claude-code)